### PR TITLE
Add independent interest level filters to each Kanban board column

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { Prospect } from "@shared/schema";
-import { STATUSES } from "@shared/schema";
+import { STATUSES, INTEREST_LEVELS } from "@shared/schema";
 import { ProspectCard } from "@/components/prospect-card";
 import { AddProspectForm } from "@/components/add-prospect-form";
-import { Briefcase, Plus } from "lucide-react";
+import { Briefcase, Plus, Filter } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,8 +13,17 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
+
+type InterestFilter = "All" | typeof INTEREST_LEVELS[number];
 
 const columnColors: Record<string, string> = {
   Bookmarked: "bg-blue-500",
@@ -30,11 +39,19 @@ function KanbanColumn({
   status,
   prospects,
   isLoading,
+  filter,
+  onFilterChange,
 }: {
   status: string;
   prospects: Prospect[];
   isLoading: boolean;
+  filter: InterestFilter;
+  onFilterChange: (value: InterestFilter) => void;
 }) {
+  const filteredProspects = filter === "All"
+    ? prospects
+    : prospects.filter((p) => p.interestLevel === filter);
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
@@ -43,13 +60,30 @@ function KanbanColumn({
       <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border/50">
         <div className={`w-2 h-2 rounded-full ${columnColors[status] || "bg-gray-400"}`} />
         <h3 className="text-sm font-semibold truncate">{status}</h3>
-        <Badge
-          variant="secondary"
-          className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
-          data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
-        >
-          {prospects.length}
-        </Badge>
+        <div className="ml-auto flex items-center gap-1.5">
+          <Select value={filter} onValueChange={(v) => onFilterChange(v as InterestFilter)}>
+            <SelectTrigger
+              className={`h-6 w-auto gap-1 px-1.5 text-[10px] border ${filter !== "All" ? "border-primary/50 bg-primary/10" : "border-border"}`}
+              data-testid={`filter-${status.replace(/\s+/g, "-").toLowerCase()}`}
+            >
+              <Filter className="w-3 h-3 shrink-0" />
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="All">All</SelectItem>
+              {INTEREST_LEVELS.map((level) => (
+                <SelectItem key={level} value={level}>{level}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Badge
+            variant="secondary"
+            className="text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
+            data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
+          >
+            {filteredProspects.length}
+          </Badge>
+        </div>
       </div>
       <div className="flex-1 overflow-y-auto px-2 py-2">
         <div className="space-y-2">
@@ -58,12 +92,14 @@ function KanbanColumn({
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
+          ) : filteredProspects.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
-              <p className="text-xs text-muted-foreground">No prospects</p>
+              <p className="text-xs text-muted-foreground">
+                {filter !== "All" ? `No ${filter.toLowerCase()} interest prospects` : "No prospects"}
+              </p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}
@@ -75,6 +111,9 @@ function KanbanColumn({
 
 export default function Home() {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [columnFilters, setColumnFilters] = useState<Record<string, InterestFilter>>(
+    () => Object.fromEntries(STATUSES.map((s) => [s, "All" as InterestFilter]))
+  );
 
   const { data: prospects, isLoading } = useQuery<Prospect[]>({
     queryKey: ["/api/prospects"],
@@ -134,6 +173,10 @@ export default function Home() {
               status={status}
               prospects={groupedByStatus[status] || []}
               isLoading={isLoading}
+              filter={columnFilters[status] || "All"}
+              onFilterChange={(value) =>
+                setColumnFilters((prev) => ({ ...prev, [status]: value }))
+              }
             />
           ))}
         </div>

--- a/replit.md
+++ b/replit.md
@@ -20,7 +20,7 @@ server/
   prospect-helpers.ts         - Pure helper functions (getNextStatus, validateProspect, isTerminalStatus)
 client/src/
   App.tsx                     - Root component, routing, providers
-  pages/home.tsx              - Kanban board with 7 status columns
+  pages/home.tsx              - Kanban board with 7 status columns, per-column interest level filter
   components/
     prospect-card.tsx         - Card component with edit/delete actions
     add-prospect-form.tsx     - Dialog form for creating prospects


### PR DESCRIPTION
Adds client-side filtering by interest level (High, Medium, Low, All) to each Kanban column in `client/src/pages/home.tsx`, updating badge counts accordingly. Updates `replit.md` to document the new feature.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 1894ef57-75a8-4bac-908b-6b66a59de13d
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 16e08985-1a56-41be-aabc-3e1573211137
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/0f5838a7-518b-4ebe-a334-120e84cf1db4/1894ef57-75a8-4bac-908b-6b66a59de13d/uD3qsK6
Replit-Helium-Checkpoint-Created: true