### PR TITLE
Add salary tracking to job applications and display it on cards

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -36,6 +36,7 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       jobUrl: "",
       status: "Bookmarked",
       interestLevel: "Medium",
+      salary: null,
       notes: "",
     },
   });
@@ -156,6 +157,34 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+                  <Input
+                    type="number"
+                    min={0}
+                    placeholder="e.g. 85000"
+                    className="pl-7"
+                    value={field.value ?? ""}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      field.onChange(val === "" ? null : Number(val));
+                    }}
+                    data-testid="input-salary"
+                  />
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -41,6 +41,7 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       jobUrl: prospect.jobUrl ?? "",
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
+      salary: prospect.salary ?? null,
       notes: prospect.notes ?? "",
     },
   });
@@ -160,6 +161,34 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
             )}
           />
         </div>
+
+        <FormField
+          control={form.control}
+          name="salary"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Target Salary (optional)</FormLabel>
+              <FormControl>
+                <div className="relative">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground text-sm">$</span>
+                  <Input
+                    type="number"
+                    min={0}
+                    placeholder="e.g. 85000"
+                    className="pl-7"
+                    value={field.value ?? ""}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      field.onChange(val === "" ? null : Number(val));
+                    }}
+                    data-testid="input-edit-salary"
+                  />
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control}

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -105,6 +105,12 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
 
         <div className="flex items-center gap-1.5 flex-wrap">
           <InterestIndicator level={prospect.interestLevel} />
+          {prospect.salary != null && (
+            <span className="inline-flex items-center gap-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400" data-testid={`text-salary-${prospect.id}`}>
+              <DollarSign className="w-3 h-3" />
+              {prospect.salary.toLocaleString("en-US")}
+            </span>
+          )}
         </div>
 
         {prospect.jobUrl && (

--- a/replit.md
+++ b/replit.md
@@ -30,7 +30,7 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, notes, created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, salary, notes, created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
 - **Interest levels**: High, Medium, Low

--- a/server/__tests__/prospect-validation.test.ts
+++ b/server/__tests__/prospect-validation.test.ts
@@ -21,3 +21,81 @@ describe("prospect creation validation", () => {
     expect(result.errors).toContain("Role title is required");
   });
 });
+
+describe("salary field validation", () => {
+  test("rejects a negative salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: -50000,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary cannot be negative");
+  });
+
+  test("allows an empty (undefined) salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("allows a null salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: null,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("allows a valid positive salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 85000,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("allows a zero salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 0,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("rejects NaN salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: NaN,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary cannot be negative");
+  });
+
+  test("rejects decimal salary", () => {
+    const result = validateProspect({
+      companyName: "Google",
+      roleTitle: "Software Engineer",
+      salary: 85000.75,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Salary cannot be negative");
+  });
+});

--- a/server/prospect-helpers.ts
+++ b/server/prospect-helpers.ts
@@ -39,6 +39,12 @@ export function validateProspect(data: Record<string, unknown>): { valid: boolea
     }
   }
 
+  if (data.salary !== undefined && data.salary !== null) {
+    if (typeof data.salary !== "number" || !Number.isFinite(data.salary) || !Number.isInteger(data.salary) || data.salary < 0) {
+      errors.push("Salary cannot be negative");
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -39,6 +39,12 @@ export async function registerRoutes(
     if (body.roleTitle !== undefined) updates.roleTitle = body.roleTitle;
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.notes !== undefined) updates.notes = body.notes;
+    if (body.salary !== undefined) {
+      if (body.salary !== null && (typeof body.salary !== "number" || !Number.isFinite(body.salary) || !Number.isInteger(body.salary) || body.salary < 0)) {
+        return res.status(400).json({ message: "Salary must be a non-negative integer" });
+      }
+      updates.salary = body.salary;
+    }
 
     if (body.status !== undefined) {
       if (!STATUSES.includes(body.status)) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, integer } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -21,6 +21,7 @@ export const prospects = pgTable("prospects", {
   jobUrl: text("job_url"),
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
+  salary: integer("salary"),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
@@ -33,6 +34,7 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   roleTitle: z.string().min(1, "Role title is required"),
   status: z.enum(STATUSES).default("Bookmarked"),
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
+  salary: z.number().int().min(0, "Salary cannot be negative").optional().nullable(),
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
 });


### PR DESCRIPTION
Implement a nullable integer 'salary' column in the prospects table, add salary input fields to the Add and Edit Job forms with validation for non-negative integers, and display the formatted salary on the ProspectCard.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 1894ef57-75a8-4bac-908b-6b66a59de13d
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 88d3b67c-c00c-4332-9084-ab5916214f2f
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/0f5838a7-518b-4ebe-a334-120e84cf1db4/1894ef57-75a8-4bac-908b-6b66a59de13d/LjWjQ1a
Replit-Helium-Checkpoint-Created: true