### PR TITLE
Add referral contact information to job tracking

### DIFF
--- a/client/src/components/add-prospect-form.tsx
+++ b/client/src/components/add-prospect-form.tsx
@@ -37,6 +37,9 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
       status: "Bookmarked",
       interestLevel: "Medium",
       salary: null,
+      referralName: "",
+      referralEmail: "",
+      referralLinkedin: "",
       notes: "",
     },
   });
@@ -185,6 +188,66 @@ export function AddProspectForm({ onSuccess }: { onSuccess?: () => void }) {
             </FormItem>
           )}
         />
+
+        <div className="space-y-3 rounded-md border border-border p-3">
+          <p className="text-sm font-medium">Referral Contact (optional)</p>
+          <FormField
+            control={form.control}
+            name="referralName"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Referral Name</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="e.g. Jane Smith"
+                    {...field}
+                    value={field.value ?? ""}
+                    data-testid="input-referral-name"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="referralEmail"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Referral Email</FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="e.g. jane@example.com"
+                    {...field}
+                    value={field.value ?? ""}
+                    data-testid="input-referral-email"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="referralLinkedin"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Referral LinkedIn</FormLabel>
+                <FormControl>
+                  <Input
+                    type="url"
+                    placeholder="https://linkedin.com/in/..."
+                    {...field}
+                    value={field.value ?? ""}
+                    data-testid="input-referral-linkedin"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
 
         <FormField
           control={form.control}

--- a/client/src/components/edit-prospect-form.tsx
+++ b/client/src/components/edit-prospect-form.tsx
@@ -42,6 +42,9 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
       status: prospect.status as InsertProspect["status"],
       interestLevel: prospect.interestLevel as InsertProspect["interestLevel"],
       salary: prospect.salary ?? null,
+      referralName: prospect.referralName ?? "",
+      referralEmail: prospect.referralEmail ?? "",
+      referralLinkedin: prospect.referralLinkedin ?? "",
       notes: prospect.notes ?? "",
     },
   });
@@ -189,6 +192,66 @@ export function EditProspectForm({ prospect, onSuccess }: EditProspectFormProps)
             </FormItem>
           )}
         />
+
+        <div className="space-y-3 rounded-md border border-border p-3">
+          <p className="text-sm font-medium">Referral Contact (optional)</p>
+          <FormField
+            control={form.control}
+            name="referralName"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Referral Name</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="e.g. Jane Smith"
+                    {...field}
+                    value={field.value ?? ""}
+                    data-testid="input-edit-referral-name"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="referralEmail"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Referral Email</FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="e.g. jane@example.com"
+                    {...field}
+                    value={field.value ?? ""}
+                    data-testid="input-edit-referral-email"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="referralLinkedin"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Referral LinkedIn</FormLabel>
+                <FormControl>
+                  <Input
+                    type="url"
+                    placeholder="https://linkedin.com/in/..."
+                    {...field}
+                    value={field.value ?? ""}
+                    data-testid="input-edit-referral-linkedin"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
 
         <FormField
           control={form.control}

--- a/client/src/components/prospect-card.tsx
+++ b/client/src/components/prospect-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Prospect } from "@shared/schema";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign } from "lucide-react";
+import { ExternalLink, Trash2, Pencil, Flame, ThumbsUp, Minus, DollarSign, UserCheck, Mail, Linkedin } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -125,6 +125,43 @@ export function ProspectCard({ prospect }: { prospect: Prospect }) {
             <ExternalLink className="w-3 h-3" />
             Posting
           </a>
+        )}
+
+        {(prospect.referralName || prospect.referralEmail || prospect.referralLinkedin) && (
+          <div className="flex items-start gap-1.5 text-xs" data-testid={`referral-${prospect.id}`}>
+            <UserCheck className="w-3 h-3 mt-0.5 shrink-0 text-violet-500" />
+            <div className="min-w-0 space-y-0.5">
+              {prospect.referralName && (
+                <p className="font-medium text-foreground truncate" data-testid={`text-referral-name-${prospect.id}`}>
+                  {prospect.referralName}
+                </p>
+              )}
+              {prospect.referralEmail && (
+                <a
+                  href={`mailto:${prospect.referralEmail}`}
+                  className="flex items-center gap-1 text-primary hover:underline truncate"
+                  onClick={(e) => e.stopPropagation()}
+                  data-testid={`link-referral-email-${prospect.id}`}
+                >
+                  <Mail className="w-3 h-3 shrink-0" />
+                  {prospect.referralEmail}
+                </a>
+              )}
+              {prospect.referralLinkedin && (
+                <a
+                  href={prospect.referralLinkedin}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-primary hover:underline truncate"
+                  onClick={(e) => e.stopPropagation()}
+                  data-testid={`link-referral-linkedin-${prospect.id}`}
+                >
+                  <Linkedin className="w-3 h-3 shrink-0" />
+                  LinkedIn
+                </a>
+              )}
+            </div>
+          </div>
         )}
 
         {prospect.notes && (

--- a/replit.md
+++ b/replit.md
@@ -30,7 +30,7 @@ client/src/
 
 ## Database
 
-Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, salary, notes, created_at.
+Single `prospects` table: id, company_name, role_title, job_url, status, interest_level, salary, referral_name, referral_email, referral_linkedin, notes, created_at.
 
 - **Statuses**: Bookmarked, Applied, Phone Screen, Interviewing, Offer, Rejected, Withdrawn
 - **Interest levels**: High, Medium, Low

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -39,6 +39,23 @@ export async function registerRoutes(
     if (body.roleTitle !== undefined) updates.roleTitle = body.roleTitle;
     if (body.jobUrl !== undefined) updates.jobUrl = body.jobUrl;
     if (body.notes !== undefined) updates.notes = body.notes;
+    if (body.referralName !== undefined) {
+      updates.referralName = (typeof body.referralName === "string" && body.referralName.trim()) ? body.referralName.trim() : null;
+    }
+    if (body.referralEmail !== undefined) {
+      const email = typeof body.referralEmail === "string" ? body.referralEmail.trim() : "";
+      if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        return res.status(400).json({ message: "Invalid referral email address" });
+      }
+      updates.referralEmail = email || null;
+    }
+    if (body.referralLinkedin !== undefined) {
+      const url = typeof body.referralLinkedin === "string" ? body.referralLinkedin.trim() : "";
+      if (url && !/^https?:\/\//i.test(url)) {
+        return res.status(400).json({ message: "Referral LinkedIn must be a valid URL starting with http(s)" });
+      }
+      updates.referralLinkedin = url || null;
+    }
     if (body.salary !== undefined) {
       if (body.salary !== null && (typeof body.salary !== "number" || !Number.isFinite(body.salary) || !Number.isInteger(body.salary) || body.salary < 0)) {
         return res.status(400).json({ message: "Salary must be a non-negative integer" });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -22,6 +22,9 @@ export const prospects = pgTable("prospects", {
   status: text("status").notNull().default("Bookmarked"),
   interestLevel: text("interest_level").notNull().default("Medium"),
   salary: integer("salary"),
+  referralName: text("referral_name"),
+  referralEmail: text("referral_email"),
+  referralLinkedin: text("referral_linkedin"),
   notes: text("notes"),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
@@ -35,6 +38,9 @@ export const insertProspectSchema = createInsertSchema(prospects).omit({
   status: z.enum(STATUSES).default("Bookmarked"),
   interestLevel: z.enum(INTEREST_LEVELS).default("Medium"),
   salary: z.number().int().min(0, "Salary cannot be negative").optional().nullable(),
+  referralName: z.string().optional().nullable(),
+  referralEmail: z.string().email("Invalid email address").optional().nullable().or(z.literal("")),
+  referralLinkedin: z.string().url("Invalid URL").optional().nullable().or(z.literal("")),
   jobUrl: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
 });


### PR DESCRIPTION
Introduces new fields for referral name, email, and LinkedIn to the job tracking application's forms and displays this information on prospect cards. Includes validation for email and URL formats in the API and frontend.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 1894ef57-75a8-4bac-908b-6b66a59de13d
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 578b7853-3bbb-4358-9a3f-23646656c1ab
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/0f5838a7-518b-4ebe-a334-120e84cf1db4/1894ef57-75a8-4bac-908b-6b66a59de13d/7m3BplW
Replit-Helium-Checkpoint-Created: true